### PR TITLE
replace deprecated string functions

### DIFF
--- a/src/acrostic.gleam
+++ b/src/acrostic.gleam
@@ -789,7 +789,7 @@ fn message_to_string(
           message.fields
           |> list.map(convert)
           |> list.fold("", fn(a, b) { a <> b <> ", " })
-          |> string.drop_right(2)
+          |> string.drop_end(2)
         }),
       ])
     }
@@ -826,5 +826,5 @@ fn pascal_to_snake(ident: String) -> String {
   |> list.map(fn(a) { a.content })
   |> list.map(fn(a) { string.lowercase(a) })
   |> list.fold("", fn(a, b) { a <> "_" <> b })
-  |> string.drop_left(1)
+  |> string.drop_start(1)
 }

--- a/src/acrostic/decoding.gleam
+++ b/src/acrostic/decoding.gleam
@@ -20,13 +20,21 @@ pub fn read_key(binary: BitArray) -> Result(#(Key, BitArray), String) {
 }
 
 pub fn to_varint(binary: BitArray, acc: Int) -> Int {
+  reverted_to_variant(binary, acc, bit_array.byte_size(binary))
+}
+
+fn reverted_to_variant(binary: BitArray, acc: Int, sum_len: Int) -> Int {
   let len = bit_array.byte_size(binary)
   case binary {
     <<byte, rest:bits>> -> {
-      to_varint(
+      reverted_to_variant(
         rest,
-        int.bitwise_shift_left(int.bitwise_and(byte, 0x7F), { len - 1 } * 7)
+        int.bitwise_shift_left(
+          int.bitwise_and(byte, 0x7F),
+          { sum_len - len } * 7,
+        )
           + acc,
+        sum_len,
       )
     }
     _ -> acc

--- a/test/acrostic_test.gleam
+++ b/test/acrostic_test.gleam
@@ -1,4 +1,6 @@
 import acrostic
+import acrostic/decoding
+import acrostic/encoding
 import gleeunit
 import gleeunit/should
 
@@ -18,4 +20,11 @@ pub fn pb_test() {
     to: "src/game.gleam",
     flags: acrostic.Flags(False, False),
   )
+}
+
+pub fn smaller_test() {
+  encoding.encode_varint(137) |> decoding.to_varint(0) |> should.equal(137)
+  encoding.encode_varint(123_456_789)
+  |> decoding.to_varint(0)
+  |> should.equal(123_456_789)
 }


### PR DESCRIPTION
`string.drop_right` and `string.drop_left` is deprecated and not longer supported in newer gleam versions